### PR TITLE
Updated killeroo-dump-noinstance.pbrt to dump treelets

### DIFF
--- a/scenes/killeroo-dump-noinstance.pbrt
+++ b/scenes/killeroo-dump-noinstance.pbrt
@@ -14,7 +14,7 @@ Sampler "halton" "integer pixelsamples" [4]
 
 Integrator "path" "integer maxdepth" [5]
 
-Accelerator "bvh" "integer dumptreeletsize" [95000]
+Accelerator "treeletdumpbvh" "integer maxtreeletbytes" [95000] "string partition" ["nvidia"] "string traversal" ["sendcheck"] "integer copyablethreshold" [0]
 
 WorldBegin
 


### PR DESCRIPTION
I think `dumptreeletsize` was renamed to `maxtreeletbytes`, which broke treelet dumping for this scene. Now the treelets are dumped.